### PR TITLE
Use a default empty set for `usernames`

### DIFF
--- a/Uscrapper.py
+++ b/Uscrapper.py
@@ -19,6 +19,7 @@ def extract_details(url, generate_report, non_strict):
     response = requests.get(url)
     soup = BeautifulSoup(response.text, 'html.parser')
 
+    usernames = []
     if non_strict:
         usernames = set(username.string for username in soup.find_all('a', href=True, string=re.compile(r'^[^\s]+$')))
 


### PR DESCRIPTION
    Use a default empty set for `usernames`
    
    Fixes
    
    ```
    Traceback (most recent call last):
      File "/Users/andrewa/stripe/Uscrapper/Uscrapper.py", line 138, in <module>
        extract_details(args.url, args.generate_report, args.nonstrict)
      File "/Users/andrewa/stripe/Uscrapper/Uscrapper.py", line 68, in extract_details
        if usernames:
    UnboundLocalError: local variable 'usernames' referenced before assignment
    ```
    
    on command `python Uscrapper.py  -u https://github.com/z0m31en7/Uscrapper/tree/main -O`
    
    ```
    $ python -V
    Python 3.9.11
    ```