### PR TITLE
Remove word boundary from phone_regex2

### DIFF
--- a/Uscrapper.py
+++ b/Uscrapper.py
@@ -33,7 +33,7 @@ def extract_details(url, generate_report, non_strict):
     extracted_emails = set(re.findall(email_regex, webpage_text))
     phone_regex3 = r'\(\d{3}\)\s\d{3}\s\d{5}'
     phone_regex = r'\b\+?\d{10,12}\b'
-    phone_regex2 = r'\b(?:\+\d{1,3}[- ]?)?\(?\d{3}\)?[- ]?\d{3}\)?[- ]?\d{4}\b'
+    phone_regex2 = r'(?:\+\d{1,3}[- ]?)?\(?\d{3}\)?[- ]?\d{3}\)?[- ]?\d{4}\b'
     extracted_phone_numbers = set(re.findall(phone_regex, webpage_text))
     extracted_phone_numbers2 = set(re.findall(phone_regex2, webpage_text))
     extracted_phone_numbers3 = set(re.findall(phone_regex3, webpage_text))


### PR DESCRIPTION
Noticed that (555)555-1234 does not match completely in the regex as-is, but returns `555)555-1234`.

This is a trivial formatting difference, and likely of no impact to workflows.

The cause for this is that `\b` matches the transition from a `\w` word character to a `[^\w]` non-word character. Numbers are word characters, but `(` is not, so the required `\b` matches the position between the `([matches here]5`, and the `\(?` cannot be matched there.


@z0m31en7 -- do you know if this change would break any purpose the `\b` was introduced for?